### PR TITLE
[Fix]orders

### DIFF
--- a/app/controllers/public/cart_items_controller.rb
+++ b/app/controllers/public/cart_items_controller.rb
@@ -21,11 +21,12 @@ class Public::CartItemsController < ApplicationController
         @cart_item.item_id = params[:item_id]
         # byebug
 
-        if @cart_item.save
+        if @cart_item.presence
+           @cart_item.save
            flash[:notice] = "#{@cart_item.item.name}をカートに追加しました。"
            redirect_to cart_items_path
-        else
-            flash[:alert] = "個数を選択してください"
+        elsif @cart_items.presence = nil
+            flash[:alert] = "商品を選択してください"
             render "public/items/show"
         end
     end

--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -47,6 +47,7 @@ class Public::OrdersController < ApplicationController
 			session[:order][:address] = address.address
 			session[:order][:addressee] = address.name
 
+
 		# 新しいお届け先が選択された時
 		elsif destination == 2
 
@@ -54,12 +55,15 @@ class Public::OrdersController < ApplicationController
 			session[:order][:post_code] = params[:post_code]
 			session[:order][:address] = params[:address]
 			session[:order][:addressee] = params[:name]
-
 		end
 
-		# お届け先情報に漏れがあればリダイレクト
-		if session[:order][:post_code].presence && session[:order][:address].presence && session[:order][:name].presence
-			redirect_to new_order_path
+		# 新しいお届け先が選択された時,お届け先情報に漏れがあればリダイレクト
+		if destination == 2
+			session[:order][:post_code].presence == nil || session[:order][:address].presence == nil || session[:order][:name].presence  == nil
+			  @customer = current_customer
+		      @addresses = Address.where(customer_id: current_customer.id)
+			  @order = Order.new
+			  render :new
 		else
 			redirect_to orders_confirm_path
 		end

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -57,7 +57,10 @@
 
 <div class = "col-xs-4 col-xs-offset-4">
     <span>
+      <% if @cart_items.presence %>
         <%= link_to "情報入力に進む", new_order_path, class: "col-xs-12 btn btn-success"%>
+      <% else %>
+      <% end %>
     </span>
     </div>
 </div>


### PR DESCRIPTION
新しいお届け先を選択した際にフォームがブランクだと確認画面に遷移できないように修正。
カートが空だと情報入力画面に進めないように修正。